### PR TITLE
Added support for Nano S Plus

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -75,6 +75,7 @@ func FindLedger() (*Ledger, error) {
 		// Workarounds for possible empty usage pages
 		deviceFound = deviceFound ||
 			(d.Product == "Nano S" && d.Interface == 0) ||
+			(d.Product == "Nano S Plus" && d.Interface == 0) ||
 			(d.Product == "Nano X" && d.Interface == 0)
 
 		if deviceFound {


### PR DESCRIPTION
I recently got the new Ledger Nano S Plus, but it doesn't work for CLI clients made by the Cosmos SDK. I tracked the problem here and tested this on the Regen chain with great success.

If there is another route preferred to add support for this (for instance by updating this repo to match upstream and making the change there), let me know (although that would also require changes in ledger-cosmos-go).