### PR TITLE
Remove suprious OSX USB Reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@
 *.dylib
 *.dll
 
+# Fortran module files - Why? For now, Allow go.mod
+#*.mod
+
 # Fortran module files
-*.mod
 *.smod
 
 # Compiled Static libraries

--- a/apduWrapper.go
+++ b/apduWrapper.go
@@ -18,6 +18,8 @@ package ledger_go
 
 import (
 	"encoding/binary"
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -68,26 +70,35 @@ func SerializePacket(
 func DeserializePacket(
 	channel uint16,
 	buffer []byte,
-	sequenceIdx uint16) (result []byte, totalResponseLength uint16, err error) {
+	sequenceIdx uint16) (result []byte, totalResponseLength uint16, isSequenceZero bool, err error) {
+
+	isSequenceZero = false
 
 	if (sequenceIdx == 0 && len(buffer) < 7) || (sequenceIdx > 0 && len(buffer) < 5) {
-		return nil, 0, errors.New("Cannot deserialize the packet. Header information is missing.")
+		return nil, 0, isSequenceZero, errors.New("Cannot deserialize the packet. Header information is missing.")
 	}
 
 	var headerOffset uint8
 
 	if codec.Uint16(buffer) != channel {
-		return nil, 0, errors.New("Invalid channel")
+		return nil, 0, isSequenceZero, errors.New(fmt.Sprintf("Invalid channel.  Expected %d, Got: %d", channel, codec.Uint16(buffer)))
 	}
 	headerOffset += 2
 
 	if buffer[headerOffset] != 0x05 {
-		return nil, 0, errors.New("Invalid tag")
+		return nil, 0, isSequenceZero, errors.New(fmt.Sprintf("Invalid tag.  Expected %d, Got: %d", 0x05, buffer[headerOffset]))
 	}
 	headerOffset++
 
-	if codec.Uint16(buffer[headerOffset:]) != sequenceIdx {
-		return nil, 0, errors.New("Wrong sequenceIdx")
+	foundSequenceIdx := codec.Uint16(buffer[headerOffset:])
+	if foundSequenceIdx == 0 {
+		isSequenceZero = true
+	} else {
+		isSequenceZero = false
+	}
+
+	if foundSequenceIdx != sequenceIdx {
+		return nil, 0, isSequenceZero, errors.New(fmt.Sprintf("Wrong sequenceIdx.  Expected %d, Got: %d", sequenceIdx, foundSequenceIdx))
 	}
 	headerOffset += 2
 
@@ -99,7 +110,7 @@ func DeserializePacket(
 	result = make([]byte, len(buffer)-int(headerOffset))
 	copy(result, buffer[headerOffset:])
 
-	return result, totalResponseLength, nil
+	return result, totalResponseLength, isSequenceZero, nil
 }
 
 // WrapCommandAPDU turns the command into a sequence of 64 byte packets
@@ -133,15 +144,33 @@ func UnwrapResponseAPDU(channel uint16, pipe <-chan []byte, packetSize int) ([]b
 	var totalSize uint16
 	var done = false
 
+	// return values from DeserializePacket
+	var result []byte
+	var responseSize uint16
+	var err error
+
+	foundZeroSequence := false
+	isSequenceZero := false
+
 	for !done {
 		// Read next packet from the channel
 		buffer := <-pipe
 
-		result, responseSize, err := DeserializePacket(channel, buffer, sequenceIdx)
+		result, responseSize, isSequenceZero, err = DeserializePacket(channel, buffer, sequenceIdx) // this may fail if the wrong sequence arrives (espeically if left over all 0000 was in the buffer from the last tx)
+
+		// Recover from a known error condition:
+		// * Discard messages left over from previous exchange until isSequenceZero == true
+		if foundZeroSequence == false && isSequenceZero == false {
+			continue
+		}
+		foundZeroSequence = true
+
 		if err != nil {
 			return nil, err
 		}
-		if sequenceIdx == 0 {
+
+		// Initialize totalSize (previously we did this if sequenceIdx == 0, but sometimes Nano X can provide the first sequenceIdx == 0 packet with all zeros, then a useful packet with sequenceIdx == 1
+		if totalSize == 0 {
 			totalSize = responseSize
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/cosmos/ledger-go
+
+go 1.17
+
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.3.0
+	github.com/zondax/hid v0.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
+github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=

--- a/ledger.go
+++ b/ledger.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/zondax/hid"
 )
@@ -86,7 +87,7 @@ func FindLedger() (*Ledger, error) {
 		}
 	}
 
-	return nil, errors.New("no ledger connected")
+	return nil, errors.New("No Ledger connected, Ledger LOCKED OR Keplr/Ledger Live may have control of device")
 }
 
 func ErrorMessage(errorCode uint16) string {
@@ -107,7 +108,7 @@ func ErrorMessage(errorCode uint16) string {
 	case 0x6985:
 		return "[APDU_CODE_CONDITIONS_NOT_SATISFIED] Conditions of use not satisfied"
 	case 0x6986:
-		return "[APDU_CODE_COMMAND_NOT_ALLOWED] Command not allowed (no current EF)"
+		return "[APDU_CODE_COMMAND_NOT_ALLOWED] Command not allowed / User Rejected (no current EF)"
 	case 0x6A80:
 		return "[APDU_CODE_BAD_KEY_HANDLE] The parameters in the data field are incorrect"
 	case 0x6B00:
@@ -116,6 +117,8 @@ func ErrorMessage(errorCode uint16) string {
 		return "[APDU_CODE_INS_NOT_SUPPORTED] Instruction code not supported or invalid"
 	case 0x6E00:
 		return "[APDU_CODE_CLA_NOT_SUPPORTED] Class not supported"
+	case 0x6E01:
+		return "[0x6E01] Ledger Connected but Cosmos App Not Open"
 	case 0x6F00:
 		return "APDU_CODE_UNKNOWN"
 	case 0x6F01:
@@ -169,17 +172,55 @@ func (ledger *Ledger) readThread() {
 			fmt.Printf("[%3d] (= %x\n", readBytes, buffer[:readBytes])
 		}
 
+		// Check for HID Read Error (May occur even during normal runtime)
 		if err != nil {
-			return
+			continue
 		}
+
+		// Discard all zero packets from Ledger Nano X on macOS
+		allZeros := true
+		for i := 0; i < 64; i++ {
+			if buffer[i] != 0 {
+				allZeros = false
+				break
+			}
+		}
+
+		// Discard all zero packet
+		if allZeros {
+			if ledger.Logging {
+				fmt.Printf("HID Returned Empty Packet - Retry\n")
+			}
+			continue
+		}
+
+		// Send data from HID to rest of program
 		select {
 		case ledger.readChannel <- buffer[:readBytes]:
+			if ledger.Logging {
+				fmt.Printf("readThread: Sent data to UnwrapResponseAPDU %d: %v\n", readBytes, buffer)
+			}
 		default:
 		}
 	}
 }
 
+func (ledger *Ledger) drainRead() {
+	// Allow time for late packet arrivals (When main program doesn't read enough packets)
+	<-time.After(50 * time.Millisecond)
+	for {
+		select {
+		case <-ledger.readChannel:
+		default:
+			return
+		}
+	}
+}
+
 func (ledger *Ledger) Exchange(command []byte) ([]byte, error) {
+	// Purge messages that arrived after previous exchange completed
+	ledger.drainRead()
+
 	if ledger.Logging {
 		fmt.Printf("[%3d]=> %x\n", len(command), command)
 	}
@@ -204,7 +245,6 @@ func (ledger *Ledger) Exchange(command []byte) ([]byte, error) {
 	}
 
 	readChannel := ledger.Read()
-
 	response, err := UnwrapResponseAPDU(Channel, readChannel, PacketSize)
 
 	if len(response) < 2 {
@@ -215,7 +255,7 @@ func (ledger *Ledger) Exchange(command []byte) ([]byte, error) {
 	sw := codec.Uint16(response[swOffset:])
 
 	if ledger.Logging {
-		fmt.Printf("Response: [%3d]<= %x [%#x]\n", len(response[:swOffset]), response[:swOffset], sw)
+		fmt.Printf("Response: [%3d]<= %x [ResultCode: %#x]\n", len(response[:swOffset]), response[:swOffset], sw)
 	}
 	if sw != 0x9000 {
 		return response[:swOffset], errors.New(ErrorMessage(sw))


### PR DESCRIPTION
Transaction approval with Ledger + OS X often fails due to:
1) Packets full of zeros being read
2) Packets out of sequence being read

This patch filters all zero filled packets and ensures each USB exchange (Send + Receive) start on proper sequence boundaries.